### PR TITLE
Show the original cause

### DIFF
--- a/src/main/groovy/com/cuisongliu/plugin/generator/mybatis/MybatisGenerator.groovy
+++ b/src/main/groovy/com/cuisongliu/plugin/generator/mybatis/MybatisGenerator.groovy
@@ -86,7 +86,7 @@ class MybatisGenerator extends DefaultTask {
 
             myBatisGenerator.generate(new GradleProgressCallback(project.mbg.consoleable), contextsToRun, fullyqualifiedTables);
         } catch (Exception e) {
-            throw new GradleException(e.getMessage());
+            throw new GradleException(e.getMessage(), e);
         }
         for (String error : warnings) {
             println(error);


### PR DESCRIPTION
This way you aren't hiding the original cause of mybatis exception.